### PR TITLE
Fix Blobstore Bug

### DIFF
--- a/portfolio/src/main/java/com/google/sps/comment/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/comment/Comment.java
@@ -17,12 +17,12 @@ public class Comment {
   private final String senderId;
   private final String message;
   @Nullable
-  private final String imgUrl;
+  private final String imgBlobKey;
 
-  public Comment(String senderId, String message, @Nullable String imgUrl) {
+  public Comment(String senderId, String message, @Nullable String imgBlobKey) {
     this.senderId = senderId;
     this.message = message;
-    this.imgUrl = imgUrl;
+    this.imgBlobKey = imgBlobKey;
   }
 
   public String getSenderId() {
@@ -34,7 +34,7 @@ public class Comment {
   }
 
   @Nullable
-  public String getImgUrl() {
-    return imgUrl;
+  public String getImgBlobKey() {
+    return imgBlobKey;
   }
 }

--- a/portfolio/src/main/java/com/google/sps/comment/repository/impl/DatastoreCommentRepository.java
+++ b/portfolio/src/main/java/com/google/sps/comment/repository/impl/DatastoreCommentRepository.java
@@ -19,7 +19,7 @@ public class DatastoreCommentRepository implements CommentRepository {
     public static final String ENTITY_NAME = "Comment";
     private static final String MESSAGE_PROPERTY = "message";
     private static final String SENDER_ID_PROPERTY = "senderId";
-    private static final String IMG_URL_PROPERTY = "imgUrl";
+    private static final String IMG_BLOB_KEY_PROPERTY = "imgBlobKey";
 
     @Override
     public void saveComment(Comment comment) {
@@ -31,7 +31,7 @@ public class DatastoreCommentRepository implements CommentRepository {
         Entity commentEntity = new Entity(ENTITY_NAME);
         commentEntity.setProperty(MESSAGE_PROPERTY, comment.getMessage());
         commentEntity.setProperty(SENDER_ID_PROPERTY, comment.getSenderId());
-        commentEntity.setProperty(IMG_URL_PROPERTY, comment.getImgUrl());
+        commentEntity.setProperty(IMG_BLOB_KEY_PROPERTY, comment.getImgUrl());
         return commentEntity;
     }
 
@@ -50,7 +50,7 @@ public class DatastoreCommentRepository implements CommentRepository {
     private Comment getCommentFromCommentEntity(Entity commentEntity) {
         return new Comment((String) commentEntity.getProperty(SENDER_ID_PROPERTY), 
                             (String) commentEntity.getProperty(MESSAGE_PROPERTY),
-                            (String) commentEntity.getProperty(IMG_URL_PROPERTY));
+                            (String) commentEntity.getProperty(IMG_BLOB_KEY_PROPERTY));
     }
 
     @Override

--- a/portfolio/src/main/java/com/google/sps/comment/repository/impl/DatastoreCommentRepository.java
+++ b/portfolio/src/main/java/com/google/sps/comment/repository/impl/DatastoreCommentRepository.java
@@ -31,7 +31,7 @@ public class DatastoreCommentRepository implements CommentRepository {
         Entity commentEntity = new Entity(ENTITY_NAME);
         commentEntity.setProperty(MESSAGE_PROPERTY, comment.getMessage());
         commentEntity.setProperty(SENDER_ID_PROPERTY, comment.getSenderId());
-        commentEntity.setProperty(IMG_BLOB_KEY_PROPERTY, comment.getImgUrl());
+        commentEntity.setProperty(IMG_BLOB_KEY_PROPERTY, comment.getImgBlobKey());
         return commentEntity;
     }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/BlobstoreServeBlobServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/BlobstoreServeBlobServlet.java
@@ -21,18 +21,21 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import com.google.appengine.api.blobstore.BlobInfo;
+import com.google.appengine.api.blobstore.BlobInfoFactory;
+import com.google.appengine.api.blobstore.BlobKey;
 
 /**
  * When the fetch() function requests the /blobstore-upload-url URL, the content of the response is
  * the URL that allows a user to upload a file to Blobstore. 
  */
 @WebServlet("/blobstore-serve-blob")
-public class BlobstoreUploadUrlServlet extends HttpServlet {
+public class BlobstoreServeBlobServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
-    BlobKey blobKey = new BlobKey(req.getParameter("blob-key"));
-    blobstoreService.serve(blobKey, resp);
+    BlobKey blobKey = new BlobKey(request.getParameter("blob-key"));
+    blobstoreService.serve(blobKey, response);
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/BlobstoreServeBlobServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/BlobstoreServeBlobServlet.java
@@ -25,10 +25,7 @@ import com.google.appengine.api.blobstore.BlobInfo;
 import com.google.appengine.api.blobstore.BlobInfoFactory;
 import com.google.appengine.api.blobstore.BlobKey;
 
-/**
- * When the fetch() function requests the /blobstore-upload-url URL, the content of the response is
- * the URL that allows a user to upload a file to Blobstore. 
- */
+/** Serves the blob with the given blobKey. */
 @WebServlet("/blobstore-serve-blob")
 public class BlobstoreServeBlobServlet extends HttpServlet {
 

--- a/portfolio/src/main/java/com/google/sps/servlets/BlobstoreServeBlobServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/BlobstoreServeBlobServlet.java
@@ -1,0 +1,38 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import com.google.appengine.api.blobstore.BlobstoreService;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * When the fetch() function requests the /blobstore-upload-url URL, the content of the response is
+ * the URL that allows a user to upload a file to Blobstore. 
+ */
+@WebServlet("/blobstore-serve-blob")
+public class BlobstoreUploadUrlServlet extends HttpServlet {
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
+    BlobKey blobKey = new BlobKey(req.getParameter("blob-key"));
+    blobstoreService.serve(blobKey, resp);
+  }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/CommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/CommentsServlet.java
@@ -131,13 +131,13 @@ public class CommentsServlet extends HttpServlet {
 
     private Comment getCommentFromRequest(String senderId, HttpServletRequest request) {
         String message = request.getParameter(COMMENT_INPUT_NAME);
-        String imgUrl = getUploadedFileUrl(request, IMG_INPUT_NAME);
-        Comment newComment = new Comment(senderId, message, imgUrl);
+        String imgBlobKey = getUploadedFileBlobKey(request, IMG_INPUT_NAME);
+        Comment newComment = new Comment(senderId, message, imgBlobKey);
         return newComment;
     }
 
     @Nullable
-    private String getUploadedFileUrl(HttpServletRequest request, String formInputElementName) {
+    private String getUploadedFileBlobKey(HttpServletRequest request, String formInputElementName) {
         BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
         Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);
         List<BlobKey> blobKeys = blobs.get(formInputElementName);
@@ -156,7 +156,7 @@ public class CommentsServlet extends HttpServlet {
             return null;
         }
 
-        ImagesService imagesService = ImagesServiceFactory.getImagesService();
+        /*ImagesService imagesService = ImagesServiceFactory.getImagesService();
         ServingUrlOptions options = ServingUrlOptions.Builder.withBlobKey(blobKey);
         try {
             URL url = new URL(imagesService.getServingUrl(options));
@@ -164,7 +164,8 @@ public class CommentsServlet extends HttpServlet {
             return url.getPath();
         } catch (MalformedURLException e) {
             return imagesService.getServingUrl(options).toString();
-        }
+        }*/
+        return blobKey.getKeyString();
     }
 
     public static String getUserEmailFromUserService() {

--- a/portfolio/src/main/java/com/google/sps/servlets/CommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/CommentsServlet.java
@@ -141,30 +141,17 @@ public class CommentsServlet extends HttpServlet {
         BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
         Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);
         List<BlobKey> blobKeys = blobs.get(formInputElementName);
-
         // User submitted form without selecting a file, so we can't get a URL. (dev server)
         if (blobKeys == null || blobKeys.isEmpty()) {
             return null;
         }
-
         BlobKey blobKey = blobKeys.get(0);
-
         // User submitted form without selecting a file, so we can't get a URL. (live server)
         BlobInfo blobInfo = new BlobInfoFactory().loadBlobInfo(blobKey);
         if (blobInfo.getSize() == 0) {
             blobstoreService.delete(blobKey);
             return null;
         }
-
-        /*ImagesService imagesService = ImagesServiceFactory.getImagesService();
-        ServingUrlOptions options = ServingUrlOptions.Builder.withBlobKey(blobKey);
-        try {
-            URL url = new URL(imagesService.getServingUrl(options));
-            // Return relative path.
-            return url.getPath();
-        } catch (MalformedURLException e) {
-            return imagesService.getServingUrl(options).toString();
-        }*/
         return blobKey.getKeyString();
     }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/ServeBlobServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ServeBlobServlet.java
@@ -26,8 +26,8 @@ import com.google.appengine.api.blobstore.BlobInfoFactory;
 import com.google.appengine.api.blobstore.BlobKey;
 
 /** Serves the blob with the given blobKey. */
-@WebServlet("/blobstore-serve-blob")
-public class BlobstoreServeBlobServlet extends HttpServlet {
+@WebServlet("/serve-blob")
+public class ServeBlobServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/portfolio/src/main/webapp/comments.js
+++ b/portfolio/src/main/webapp/comments.js
@@ -94,7 +94,7 @@ function createParagraphElement(string) {
 }
 
 function createImgElement(srcBlobKey) {
-    var url = new URL("/blobstore-serve-blob", document.URL);
+    var url = new URL("/serve-blob", document.URL);
     url.searchParams.append('blob-key', srcBlobKey)
     var img = document.createElement("img");
     img.src = url;

--- a/portfolio/src/main/webapp/comments.js
+++ b/portfolio/src/main/webapp/comments.js
@@ -35,8 +35,9 @@ function addCommentToDOM(commentData) {
     card.appendChild(senderNameHeading);
     card.appendChild(messageParagraph);
     card.appendChild(emailHeading);
-    if (commentData.comment.imgUrl !== undefined) {
-        var img  = createImgElement(commentData.comment.imgUrl);
+    if (commentData.comment.imgBlobKey !== undefined) {
+        console.log("adding img to comment with message: " + commentData.comment.message + " and blobKey: + " + commentData.comment.imgBlobKey);
+        var img  = createImgElement(commentData.comment.imgBlobKey);
         card.appendChild(img);
     }
     cardHolder.appendChild(card);
@@ -92,8 +93,10 @@ function createParagraphElement(string) {
     return paragraph;
 }
 
-function createImgElement(srcUrl){
+function createImgElement(srcBlobKey) {
+    var url = new URL("/blobstore-serve-blob", document.URL);
+    url.searchParams.append('blob-key', srcBlobKey)
     var img = document.createElement("img");
-    img.src = srcUrl;
+    img.src = url;
     return img;
 }


### PR DESCRIPTION
The recent changes fix a bug which was specific to the live server.

I discovered that although the images could be uploaded, stored and displayed correctly on the test server, the ImageService failed on the live server. I fixed this bug by avoiding the usage of ImageService: in the datastore I store the key of the blob instead of the image's url, and for displaying the image on the comments page, I use the BlobstoreService's serve function in the BlobstoreServeBlobServlet. 

This approach works as expected both on the test server and on the live server.

See go/step2020-intern-tech-guide for more info about the bug. 

